### PR TITLE
cd: Add GitHub action to deploy website to AWS

### DIFF
--- a/.github/workflows/cd-release-doc.yml
+++ b/.github/workflows/cd-release-doc.yml
@@ -1,0 +1,41 @@
+---
+# Automates deploy of comptox_ai doc page to AWS on GitHub release
+name: cd-release-doc
+
+# Deployed on release or on workflow dispatch
+on:
+  release:
+  workflow_dispatch:
+
+# Define the jobs in the workflow
+jobs:
+  release-doc:
+    runs-on: ubuntu-latest
+    # # These permissions are needed to interact with
+    # GitHub's OIDC Token endpoint.
+    # permissions: id-token: write contents: read
+
+    # # You can change the default value as needed
+    # env:
+    #   # Directory of docs
+    #   doc-directory: ./docs
+
+    steps:
+      # Step: Check out the repository's code to the runner
+      - name: checkout-code
+        uses: actions/checkout@v3
+
+      # Step: Deploy to server
+      - name: deploy-to-server
+        uses: easingthemes/ssh-deploy@v2
+        with:
+          SSH_PRIVATE_KEY: ${{ secrets.COMPTOX_AI_AWS_SSH }}
+          REMOTE_HOST: 'ec2-54-196-111-219.compute-1.amazonaws.com'
+          REMOTE_USER: 'ec2-user'
+          SOURCE: ./docs/build/
+          TARGET: '/home/ec2-user/ComptoxAiWeb'
+# # Step: Configure AWS credentials from AWS role
+# - name: configure-credential uses:
+#   aws-actions/configure-aws-credentials@v3 with: role-to-assume:
+#   arn:aws:iam::146408842325:role/comptox_ai_website aws-region:
+#   us-east-1 run:


### PR DESCRIPTION
[#63] Refer to GitHub issue…

This update creates a GitHub action that deploys ComptoxAI website to AWS EC2 instance on GitHub release.
The action uses a pre-made GitHub action from
easingthemes/ssh-deploy@v2.
The ssh keys needed are called from GitHub secret.

In the future, there should be a review on whether changing the authentication method to AWS role is a safer method. In this case, the action must be built from scratch rather than using an external one as it uses different parameters.