### PR TITLE
fix: Change AWS deploy action auth method

### DIFF
--- a/.github/workflows/cd-release-doc.yml
+++ b/.github/workflows/cd-release-doc.yml
@@ -5,43 +5,30 @@ name: cd-release-doc
 # Deployed on release or on workflow dispatch
 on:
   release:
+    types:
+      - created
   workflow_dispatch:
 
 # Define the jobs in the workflow
 jobs:
   release-doc:
     runs-on: ubuntu-latest
-    # # These permissions are needed to interact with
-    # GitHub's OIDC Token endpoint.
-    # permissions: id-token: write contents: read
-
-    # # You can change the default value as needed
-    # env:
-    #   # Directory of docs
-    #   doc-directory: ./docs
 
     steps:
       # Step: Check out the repository's code to the runner
       - name: checkout-code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
-      # Step: Install Node.js
-      - name: install-node
-        uses: actions/setup-node@v3
+      # Step: Configure AWS credentials from AWS role
+      - name: configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          node-version: '16.x'
+          role-to-assume: arn:aws:iam::146408842325:role/comptox_ai
+          aws-region: us-east-1
 
-      # Step: Deploy to server
-      - name: deploy-to-server
-        uses: easingthemes/ssh-deploy@v2
-        with:
-          SSH_PRIVATE_KEY: ${{ secrets.COMPTOX_AI_AWS_SSH }}
-          REMOTE_HOST: 'ec2-54-92-148-244.compute-1.amazonaws.com'
-          REMOTE_USER: 'ec2-user'
-          SOURCE: ./docs/build/
-          TARGET: '/home/ec2-user/ComptoxAiWeb'
-# # Step: Configure AWS credentials from AWS role
-# - name: configure-credential uses:
-#   aws-actions/configure-aws-credentials@v3 with: role-to-assume:
-#   arn:aws:iam::146408842325:role/comptox_ai_website aws-region:
-#   us-east-1 run:
+      # Step: Run deploy script on the EC2 instance
+      - name: deploy-to-ec2
+        run: |
+          rsync -avz --no-times \
+          ./docs/build/html/. \
+          ec2-user@54.92.148.244:/usr/share/nginx/html/


### PR DESCRIPTION
This update changed the authentication method for AWS deploy action. Previously, SSH key was used to deploy.
The current method uses AWS credentials with AWS role.