### PR TITLE
style: Change settings to apply Python isort

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -216,8 +216,12 @@
   // Python formatter: PEP8
   "[python]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "ms-python.autopep8"
+    "editor.defaultFormatter": "ms-python.autopep8",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
   },
+  "isort.args": ["--profile", "black"],
 
   // Python testing: PyTest
   "python.testing.pytestArgs": ["tests"],


### PR DESCRIPTION
[#62] Refer to GitHub issue…

The purpose of this update is to fix VSCode setting in order to apply Python isort properly.
isort will now be applied automatically on save, with its profile setting based on Black.