### PR TITLE
fix: Change 'api/app.js' redirection to 'localhost:3000/api'

### DIFF
--- a/web/packages/api/app.js
+++ b/web/packages/api/app.js
@@ -14,7 +14,7 @@ import routes from './routes';
 
 const port = 3000;
 
-const HOST = process.env.NODE_ENV === 'production' ? 'https://comptox.ai/api' : 'http://localhost:3000';
+const HOST = process.env.NODE_ENV === 'production' ? 'https://comptox.ai/api' : 'http://localhost:3000/api';
 
 const swaggerOpts = {
   definition: {

--- a/web/packages/api/app.js
+++ b/web/packages/api/app.js
@@ -1,53 +1,52 @@
-const express = require('express');
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import express from 'express';
+import methodOverride from 'method-override';
+import swaggerJSDoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
 
-const nconf = require('./config');
-const routes = require('./routes');
-const neo4jSessionCleanup = require("./middleware/neo4jSessionCleanup");
-const writeError = require("./helpers/response").writeError;
+import dataConfigJson from './assets/data.json';
+import { writeError } from './helpers/response';
+import neo4jSessionCleanup from './middleware/neo4jSessionCleanup';
+import nconf from './config';
+import neo4jMiddleware from './neo4j';
+import routes from './routes';
 
-const dataConfigJson = require('./assets/data.json');
+const port = 3000;
 
-const app = express();
-const swaggerJSDoc = require('swagger-jsdoc');
-const swaggerUi = require('swagger-ui-express');
-const bodyParser = require('body-parser');
-const methodOverride = require('method-override');
-const path = require('path');
-const cors = require('cors');
+const HOST = process.env.NODE_ENV === 'production' ? 'https://comptox.ai/api' : 'http://localhost:3000';
 
-const port = 3000
-
-const HOST = (process.env.NODE_ENV === 'production') ? 'https://comptox.ai/api' : 'http://localhost:3000';
-
-var swaggerOpts = {
-    definition: {
-        openapi: '3.0.3',
-        info: {
-            title: "ComptoxAI REST API",
-            version: "1.0.0",
-            description: "A REST Web API providing programmatic access to ComptoxAI's graph database.",
-        },
-        servers: [
-            {
-                url: "https://comptox.ai/api",
-                description: "ComptoxAI's public REST API"
-            },
-            {
-                url: "http://localhost:3000",
-                description: "Default local (dev) API server"
-            }
-        ],
-        host: HOST,
+const swaggerOpts = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'ComptoxAI REST API',
+      version: '1.0.0',
+      description: 'A REST Web API providing programmatic access to ComptoxAI\'s graph database.',
     },
-    apis: ["./routes/*.js", "./*.js"],
+    servers: [
+      {
+        url: 'https://comptox.ai/api',
+        description: 'ComptoxAI\'s public REST API',
+      },
+      {
+        url: 'http://localhost:3000/api',
+        description: 'Default local (dev) API server',
+      },
+    ],
+    host: HOST,
+  },
+  apis: ['./routes/*.js', './*.js'],
 };
 
 // Make swagger/openapi documentation
-var swaggerSpec = swaggerJSDoc(swaggerOpts);
-app.use('/help', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-app.set("port", nconf.get("PORT"));
+const swaggerSpec = swaggerJSDoc(swaggerOpts);
+const app = express();
 
-app.use(require('./neo4j'));
+app.use('/help', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.set('port', nconf.get('PORT'));
+
+app.use(neo4jMiddleware);
 
 app.use(bodyParser.json());
 app.use(methodOverride());
@@ -55,21 +54,21 @@ app.use(methodOverride());
 app.use(cors());
 
 // CORS: Important for Open API and other things
-app.use(function (req, res, next) {
-    // res.header("Access-Control-Allow-Origin", "*");
-    // res.header("Access-Control-Allow-Credentials", "true");
-    // // res.header("Access-Control-Allow-Credentials", "false");
-    // res.header(
-    //     "Access-Control-Allow-Methods",
-    //     "GET,HEAD,OPTIONS,POST,PUT,DELETE"
-    // );
-    // res.header(
-    //     "Access-Control-Allow-Headers",
-    //     "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Auth-Token"
-    // );    
-    // Make everything be returned as JSON
-    res.header("Content-Type", 'application/json');
-    next();
+app.use((_, res, next) => {
+  // res.header('Access-Control-Allow-Origin', '*');
+  // res.header('Access-Control-Allow-Credentials', 'true');
+  // // res.header('Access-Control-Allow-Credentials', 'false');
+  // res.header(
+  //     'Access-Control-Allow-Methods',
+  //     'GET,HEAD,OPTIONS,POST,PUT,DELETE'
+  // );
+  // res.header(
+  //     'Access-Control-Allow-Headers',
+  //     'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Auth-Token'
+  // );
+  // Make everything be returned as JSON
+  res.header('Content-Type', 'application/json');
+  next();
 });
 
 app.options('*', cors());
@@ -80,7 +79,7 @@ app.use(neo4jSessionCleanup);
  * @openapi
  * /:
  *   get:
- *     description: Return a string 
+ *     description: Return a string
  *     summary: Display a welcome message
  *     responses:
  *       200:
@@ -90,9 +89,11 @@ app.use(neo4jSessionCleanup);
  *             schema:
  *               type: string
  */
-app.get('/', (req, res) => {
-    res.send('Welcome to ComptoxAI\'s web API! Please read the documentation at http://comptox.ai/api/help/ for available operations.')
-})
+app.get('/', (_, res) => {
+  res.send(
+    'Welcome to ComptoxAI\'s web API! Please read the documentation at http://comptox.ai/api/help/ for available operations.',
+  );
+});
 
 /**
  * @openapi
@@ -108,37 +109,41 @@ app.get('/', (req, res) => {
  *             schema:
  *               type: object
  */
-app.get('/config', (req, res) => {
-    console.log(dataConfigJson);
-    res.json(dataConfigJson);
-})
-
-// Note: We use bodyParser here to enable text data in the request body
-app.post("/chemicals/structureSearch", bodyParser.text({type: '*/*'}), routes.chemicals.structureSearch);
-
-app.get("/nodes/listNodeTypes", routes.nodes.listNodeTypes);
-app.get("/nodes/listNodeTypeProperties/:type", routes.nodes.listNodeTypeProperties);
-// example: http://localhost:3000/nodes/Chemical/search?field=xrefDTXSID&value=DTXSID30857908
-app.get("/nodes/:type/search?", routes.nodes.findNode);
-app.get("/nodes/:type/searchContains?", routes.nodes.findNodeContains);
-app.get("/nodes/fetchById/:id", routes.nodes.fetchById);
-app.get("/nodes/fetchChemicalByDtsxid/:id", routes.nodes.fetchChemicalByDtsxid);
-
-app.get("/relationships/fromStartNodeId/:id", routes.relationships.findRelationshipsByNode);
-
-app.get("/paths/findByIds?", routes.paths.findByIds)
-
-app.get("/datasets/makeQsarDataset?", routes.datasets.makeQsarDataset)
-
-app.get("/graphs/test", routes.graphs.testGraphs)
-
-// handle errors
-app.use(function (err, req, res, next) {
-    if (err && err.status) {
-        writeError(res, err);
-    } else next(err);
+app.get('/config', (_, res) => {
+  console.log(dataConfigJson);
+  res.json(dataConfigJson);
 });
 
-app.listen(app.get("port"), () => {
-    console.log(`ComptoxAI API listening at http://localhost:${port}`);
+// Note: We use bodyParser here to enable text data in the request body
+app.post(
+  '/chemicals/structureSearch',
+  bodyParser.text({ type: '*/*' }),
+  routes.chemicals.structureSearch,
+);
+
+app.get('/nodes/listNodeTypes', routes.nodes.listNodeTypes);
+app.get('/nodes/listNodeTypeProperties/:type', routes.nodes.listNodeTypeProperties);
+// example: http://localhost:3000/nodes/Chemical/search?field=xrefDTXSID&value=DTXSID30857908
+app.get('/nodes/:type/search?', routes.nodes.findNode);
+app.get('/nodes/:type/searchContains?', routes.nodes.findNodeContains);
+app.get('/nodes/fetchById/:id', routes.nodes.fetchById);
+app.get('/nodes/fetchChemicalByDtsxid/:id', routes.nodes.fetchChemicalByDtsxid);
+
+app.get('/relationships/fromStartNodeId/:id', routes.relationships.findRelationshipsByNode);
+
+app.get('/paths/findByIds?', routes.paths.findByIds);
+
+app.get('/datasets/makeQsarDataset?', routes.datasets.makeQsarDataset);
+
+app.get('/graphs/test', routes.graphs.testGraphs);
+
+// handle errors
+app.use((err, _, res, next) => {
+  if (err && err.status) {
+    writeError(res, err);
+  } else next(err);
+});
+
+app.listen(app.get('port'), () => {
+  console.log(`ComptoxAI API listening at http://localhost:${port}/api`);
 });


### PR DESCRIPTION
[#76] Refer to GitHub issue...

This update addresses the following:

- Corrected the redirection URL from 'http://localhost:3000' to 'http://localhost:3000/api' to ensure that address redirection functions correctly. With this change,
'http://ec2-<ip>.compute-1.amazonaws.com/api' will correctly redirect to the API page as intended.

Additionally, this update includes the following changes:

- Reformatted constant imports to use 'import' to align with the ES6 style guide and reordered them based on the import order standard.
- Replaced some double quotations with single quotations to maintain consistent coding style.
- Replaced certain 'req' variables used in functions with '_' to resolve ESLint issues related to unused variables.
- Updated some functions to use ES6 arrow function syntax for improved code readability.

These changes enhance code clarity and maintain consistency with coding standards.