### PR TITLE
fix: Resolve redirection error for /api path

### DIFF
--- a/web/packages/api/app.js
+++ b/web/packages/api/app.js
@@ -17,7 +17,7 @@ const cors = require('cors');
 
 const port = 3000;
 
-const HOST = (process.env.NODE_ENV === 'production') ? 'https://comptox.ai/api' : 'http://localhost:3000';
+const HOST = (process.env.NODE_ENV === 'production') ? 'https://comptox.ai/api' : 'http://0.0.0.0:3000';
 
 const swaggerOpts = {
   definition: {
@@ -33,7 +33,7 @@ const swaggerOpts = {
         description: 'ComptoxAI\'s public REST API',
       },
       {
-        url: 'http://localhost:3000',
+        url: 'http://0.0.0.0:3001',
         description: 'Default local (dev) API server',
       },
     ],
@@ -118,7 +118,7 @@ app.post('/chemicals/structureSearch', bodyParser.text({ type: '*/*' }), routes.
 
 app.get('/nodes/listNodeTypes', routes.nodes.listNodeTypes);
 app.get('/nodes/listNodeTypeProperties/:type', routes.nodes.listNodeTypeProperties);
-// example: http://localhost:3000/nodes/Chemical/search?field=xrefDTXSID&value=DTXSID30857908
+// example: http://0.0.0.0:3000/nodes/Chemical/search?field=xrefDTXSID&value=DTXSID30857908
 app.get('/nodes/:type/search?', routes.nodes.findNode);
 app.get('/nodes/:type/searchContains?', routes.nodes.findNodeContains);
 app.get('/nodes/fetchById/:id', routes.nodes.fetchById);
@@ -140,5 +140,5 @@ app.use((err, req, res, next) => {
 });
 
 app.listen(app.get('port'), () => {
-  console.log(`ComptoxAI API listening at http://localhost:${port}`);
+  console.log(`ComptoxAI API listening at http://0.0.0.0:${port}`);
 });

--- a/web/packages/api/config.js
+++ b/web/packages/api/config.js
@@ -1,35 +1,33 @@
-'use strict';
-
 require('dotenv').config();
 
-var nconf = require('nconf');
+const nconf = require('nconf');
 
 nconf.env(['PORT', 'NODE_ENV']).argv({
-    'e': {
-        alias: 'NODE_ENV',
-        describe: 'Specify development or production mode for running app.',
-        demand: false,
-        default: 'development',
-    },
-    'p': {
-        alias: 'PORT',
-        describe: 'Port used to serve API application.',
-        demand: false,
-        default: 3000,
-    },
-    'n': {
-        alias: 'neo4j',
-        describe: 'Specify whether to use remote or local Neo4j instance.',
-        demand: false,
-        default: 'local'
-    }
+  e: {
+    alias: 'NODE_ENV',
+    describe: 'Specify development or production mode for running app.',
+    demand: false,
+    default: 'development',
+  },
+  p: {
+    alias: 'PORT',
+    describe: 'Port used to serve API application.',
+    demand: false,
+    default: 3000,
+  },
+  n: {
+    alias: 'neo4j',
+    describe: 'Specify whether to use remote or local Neo4j instance.',
+    demand: false,
+    default: 'local',
+  },
 }).defaults({
-    'USERNAME': process.env.COMPTOX_AI_DATABASE_USERNAME,
-    'PASSWORD': process.env.COMPTOX_AI_DATABASE_PASSWORD,
-    'neo4j': 'local',
-    'neo4j-local': process.env.COMPTOX_AI_DATABASE_URL || 'bolt://165.123.13.192:7687',
-    'base_url': 'http://localhost:3000',
-    'api_path': '/api',
+  USERNAME: process.env.COMPTOX_AI_DATABASE_USERNAME,
+  PASSWORD: process.env.COMPTOX_AI_DATABASE_PASSWORD,
+  neo4j: 'local',
+  'neo4j-local': process.env.COMPTOX_AI_DATABASE_URL || 'bolt://165.123.13.192:7687',
+  base_url: 'http://0.0.0.0:3000',
+  api_path: '/api',
 });
 
 module.exports = nconf;

--- a/web/packages/app/package.json
+++ b/web/packages/app/package.json
@@ -25,7 +25,7 @@
     "redux-form": "^8.3.10"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts start --port 3001",
     "build": "DISABLE_ESLINT_PLUGIN=true node ./scripts/build-custom.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
[#63] Refer to GitHub issue...

This update addresses the redirection error on EC2 for the /api path. The issue was related to DNS resolution, which has now been resolved.

Changes Made:
- Replaced all references to 'http://localhost:3000' in /api/app.js and /api/config.js with 'http://0.0.0.0:3000' to prevent potential DNS resolution issues.

Additional Information:
- Running 'npm start' will now launch the React app on port 3001 (http://localhost:3001) to avoid conflicts with the API, which is prioritized to run on port 3000.

Note:
- A change was also made in the EC2 nginx.conf file. 'http://localhost:3000' was updated to 'http://127.0.0.1:3000/' to prevent DNS resolution issues.