### PR TITLE
chore: Fix `ci-app-build` and `ci-doc-build`

### DIFF
--- a/.github/workflows/ci-app-build.yml
+++ b/.github/workflows/ci-app-build.yml
@@ -18,7 +18,7 @@ jobs:
     # You can change the default value as needed
     env:
       # Directory of React app
-      app-directory: /comptox_ai/web/packages/app
+      app-directory: ./web/packages/app
 
     steps:
       # Step: Check out the repository's code to the runner

--- a/.github/workflows/ci-doc-build.yml
+++ b/.github/workflows/ci-doc-build.yml
@@ -40,7 +40,7 @@ jobs:
       # Step: Install project dependencies using pip
       - name: install-dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools wheel
           python -m pip install ".[docs]"
         # Modify the name inside the brackets to match the name of the
         # extras_require you would like to install. There should be no


### PR DESCRIPTION
[#89] Refer to GitHub issue...

This commit addresses the following changes:

- Modified `ci-app-build` to fix a directory error.
- Added the `wheel` package to `ci-doc-build` to improve package installation speed.