### PR TITLE
chore: Revert Python version on GitHub action

### DIFF
--- a/.github/workflows/ci-python-test.yml
+++ b/.github/workflows/ci-python-test.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         # You can change the default value as needed
-        # python-version: ['3.8', '3.9', '3.10']
-        python-version: ['3.8']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       # Step: Check out the repository's code to the runner


### PR DESCRIPTION
[#89] Refer to GitHub issue...

This update reverts the Python versions tested in `ci-python-test.yml` to Python versions 3.8, 3.9, and 3.10.

Previously, we had made changes to test a different only Python version 3.8 for test speed as continuous minor fixes needed to be made and tested. After further consideration and testing, we are reverting to these versions for compatibility and stability reasons.