### PR TITLE
chore: Fix directory reference in `ci-doc-build`

### DIFF
--- a/.github/workflows/ci-doc-build.yml
+++ b/.github/workflows/ci-doc-build.yml
@@ -18,7 +18,7 @@ jobs:
     # You can change the default value as needed
     env:
       # Directory of docs
-      doc-directory: /comptox_ai/docs
+      doc-directory: ./docs
 
     # Define strategy for matrix builds
     strategy:


### PR DESCRIPTION
[#89] Refer to GitHub issue...

In this update, we address an issue in the `ci-doc-build` workflow. The error was related to an incorrect directory reference for `docs`, which caused the workflow to fail.

To resolve this error, we have made a change to the directory reference, ensuring that the workflow now correctly accesses the `docs` directory. This change should prevent the error and ensure the workflow runs smoothly.