### PR TITLE
docs: Simplify GitHub Action badge text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,10 @@
 # `ComptoxAI`
 
-[python-badge]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-python-test.yml/badge.svg
-[web-app-badge]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-app-build.yml/badge.svg
-[docs-badge]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-doc-build.yml/badge.svg
-
-[python-link]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-python-test.yml
-[web-app-link]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-app-build.yml
-[docs-link]: https://github.com/jdromano2/comptox_ai/actions/workflows/ci-doc-build.yml
-
 [![DOI](https://zenodo.org/badge/202416245.svg)](https://zenodo.org/badge/latestdoi/202416245)
 
-[![Python test][python-badge]][python-link]
-[![React build][web-app-badge]][web-app-link]
-[![Documentation build][docs-badge]][docs-link]
+[![Python test](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-python-test.yml/badge.svg)](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-python-test.yml)
+[![React build](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-app-build.yml/badge.svg)](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-app-build.yml)
+[![Documentation build](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-doc-build.yml/badge.svg)](https://github.com/jdromano2/comptox_ai/actions/workflows/ci-doc-build.yml)
 
 [Website](https://comptox.ai/)
 


### PR DESCRIPTION
[#89] Refer to GitHub issue...

This update aims to address the issue with GitHub's README page not displaying alt text correctly for GitHub Action badge status. The README Markdown for badge status has been simplified to make it more straightforward. While this change may not guarantee a fix on the GitHub page, it serves as an attempt to improve badge rendering. The update doesn't alter any functionality from the previous version and will be retained regardless of its impact on the GitHub README page.