### PR TITLE
chore: Switch math rendering in Sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,15 +6,17 @@
 
 # -- Project information -----------------------------------------------------
 
-import re
-from sphinx.util.inspect import safe_getattr
-from docutils.parsers.rst import directives
-from sphinx.ext.autosummary import Autosummary, get_documenter
-import ablog
-import comptox_ai
 import os
+import re
 import sys
 from datetime import datetime
+
+import ablog
+from docutils.parsers.rst import directives
+from sphinx.ext.autosummary import Autosummary, get_documenter
+from sphinx.util.inspect import safe_getattr
+
+import comptox_ai
 
 project = 'ComptoxAI'
 copyright = f'(c) {datetime.now().year} by Joseph D. Romano (MIT License)'
@@ -89,13 +91,17 @@ def setup(app):
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.imgmath',
     'sphinx.ext.autosummary',  # note: automatically loaded by numpydoc
     'sphinx.ext.coverage',
     'numpydoc',
     'ablog',
-    'sphinxext.opengraph'
+    'sphinxext.opengraph',
+    'sphinx-mathjax-offline',
+    'sphinxcontrib.bibtex'
 ]
+
+bibtex_bibfiles = ['refs.bib']
+
 
 imgmath_image_format = 'svg'
 imgmath_font_size = 14

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setuptools.setup(
         'testing': ['pytest'],
         'coverage': ['pytest-cov', 'codecov'],
         'docs': ['numpydoc', 'sphinxext-opengraph', 'ablog==0.10.19',
-                 'sphinx==6.2.1', 'docutils>=0.19', 'Jinja2>=3.0'],
+                 'sphinx==6.2.1', 'docutils>=0.19', 'Jinja2>=3.0',
+                 'sphinxcontrib-bibtex', 'sphinx-mathjax-offline'],
         'styling': ['isort']
     },
     entry_points={


### PR DESCRIPTION
[#87, #101, #105] Refer to GitHub issue...

Transitioned from `sphinx.ext.imgmath` to `sphinx-mathjax-offline` for improved compatibility with our EC2 setup. Previous method needed LaTeX on EC2, a challenge for our free-tier instance.

Main changes:
- Introduced `sphinx-mathjax-offline` for offline LaTeX rendering without system-level dependencies.
- Added `sphinxcontrib.bibtex` for BibTeX-based citations.
- Autoformatted imports in `docs/source/conf.py`.

Brief Comparison:
- `sphinx.ext.imgmath`: Converts math to images; requires LaTeX on build system; consistent visuals but resource-heavy.
- `sphinx-mathjax-offline`: Uses offline MathJax for crisp, scalable math rendering; no system-level dependencies.

For a detailed comparison, refer to
https://github.com/RomanoLab/comptox_ai/issues/105